### PR TITLE
Java example: how to intercept methods calls for collecting test steps

### DIFF
--- a/functional test automation/webdriver/methods-interceptor/README.md
+++ b/functional test automation/webdriver/methods-interceptor/README.md
@@ -1,0 +1,48 @@
+Java example: how to intercept methods calls for collecting test steps
+======
+
+Implemented via maven, testng.
+
+Main usage: collecting steps that were intercepted during tests' execution. This data could be used in
+test results report for increasing understanding of what was tested.
+
+Inside of project you will see: 
+ 
+ - Reflection utils implementation for intercepting methods calls
+ - Custom annotations for tracking what methods need to be intercepted
+ - Custom page factory implementation for creating page objects via reflection with methods interceptor
+ - Simple page object and base test for test background preparation
+ - Simple test that prints used annotated methods' names 
+
+
+Test looks like the following:
+```java
+package info.testing.automated.tests;
+
+import info.testing.automated.core.BaseTest;
+import info.testing.automated.utils.ReflectionUtils;
+import org.testng.annotations.Test;
+
+import static info.testing.automated.utils.ReflectionUtils.getMethodsCallsList;
+
+/**
+ * Author: Serhii Kuts
+ */
+public class MethodsInterceptorTests extends BaseTest {
+
+    @Test
+    public void interceptAndPublish() throws Exception {
+        samplePage()
+                .firstAction()
+                .secondAction()
+                .thirdAction()
+                .fourthAction();
+
+        for (String method : getMethodsCallsList()) {
+            System.out.println(method);
+        }
+
+        Thread.sleep(3000);
+    }
+}
+```

--- a/functional test automation/webdriver/methods-interceptor/pom.xml
+++ b/functional test automation/webdriver/methods-interceptor/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>info.testing.atuomated</groupId>
+    <artifactId>methods-interceptor</artifactId>
+    <version>1.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.8.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.12.1.GA</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.1</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/annotations/Publish.java
+++ b/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/annotations/Publish.java
@@ -1,0 +1,14 @@
+package info.testing.automated.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Author: Serhii Kuts
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.METHOD, ElementType.TYPE })
+public @interface Publish {
+}

--- a/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/annotations/ThrowsException.java
+++ b/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/annotations/ThrowsException.java
@@ -1,0 +1,14 @@
+package info.testing.automated.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Author: Serhii Kuts
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.METHOD, ElementType.TYPE })
+public @interface ThrowsException {
+}

--- a/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/core/BasePage.java
+++ b/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/core/BasePage.java
@@ -1,0 +1,10 @@
+package info.testing.automated.core;
+
+/**
+ * Author: Serhii Kuts
+ */
+public class BasePage {
+
+    public BasePage(WebDriver driver) {
+    }
+}

--- a/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/core/WebDriver.java
+++ b/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/core/WebDriver.java
@@ -1,0 +1,10 @@
+package info.testing.automated.core;
+
+/**
+ * Author: Serhii Kuts
+ */
+public class WebDriver {
+
+    public void quit() {
+    }
+}

--- a/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/utils/ReflectionUtils.java
+++ b/functional test automation/webdriver/methods-interceptor/src/main/java/info/testing/automated/utils/ReflectionUtils.java
@@ -1,0 +1,107 @@
+package info.testing.automated.utils;
+
+import info.testing.automated.annotations.Publish;
+import info.testing.automated.annotations.ThrowsException;
+import javassist.util.proxy.MethodFilter;
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Author: Serhii Kuts
+ */
+public final class ReflectionUtils {
+
+    private static final ThreadLocal<List<String>> METHODS_CALLS = new ThreadLocal<>();
+
+    private ReflectionUtils() {
+    }
+
+    @SuppressWarnings(value = "unchecked")
+    public static Object getInstance(final Class clazz, final Object... args) {
+        Object instance;
+
+        try {
+            if (args != null && args.length > 0) {
+                final Class[] classes = new Class[args.length];
+                int counter = 0;
+
+                for (Object arg : args) {
+                    classes[counter++] = arg.getClass();
+                }
+
+                instance = clazz.getConstructor(classes).newInstance(args);
+            } else {
+                instance = clazz.getConstructor().newInstance();
+            }
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            // log error here
+            instance = null;
+        }
+
+        return instance;
+    }
+
+    @SuppressWarnings(value = "unchecked")
+    public static <T> T create(final Class<T> clazz, final Object... args) {
+        final ProxyFactory factory = new ProxyFactory();
+        factory.setSuperclass(clazz);
+        factory.setFilter(getPackageFilter(clazz.getPackage().getName()));
+
+        final MethodHandler handler = new MethodHandler() {
+            @Override
+            public Object invoke(final Object self, final Method overridden, final Method forwarder,
+                                 final Object[] args) throws Exception {
+                getMethodsCallsList().add(overridden.getName() +
+                        "(" + Arrays.deepToString(args).replaceAll("\\[|\\]", "") + ")");
+
+                try {
+                    return forwarder.invoke(self, args);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    // throw your custom exception for annotated methods, otherwise - skip
+                    if (overridden.getAnnotation(ThrowsException.class) != null) {
+                        throw new Exception();
+                    }
+                    return null;
+                }
+            }
+        };
+
+        final Object instance = getInstance(factory.createClass(), args);
+
+        if (instance != null) {
+            ((ProxyObject) instance).setHandler(handler);
+        }
+
+        return (T) instance;
+    }
+
+    public static MethodFilter getPackageFilter(final String packageName) {
+        return new MethodFilter() {
+            public boolean isHandled(final Method method) {
+                return method.getDeclaringClass().getName().contains(packageName) &&
+                        method.getAnnotation(Publish.class) != null;
+            }
+        };
+    }
+
+    public static List<String> getMethodsCallsList() {
+        if (METHODS_CALLS.get() == null) {
+            METHODS_CALLS.set(new ArrayList<String>());
+        }
+
+        return METHODS_CALLS.get();
+    }
+
+    public static void clearMethodsCallsList() {
+        if (METHODS_CALLS.get() != null) {
+            METHODS_CALLS.remove();
+        }
+    }
+}

--- a/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/core/BaseTest.java
+++ b/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/core/BaseTest.java
@@ -1,0 +1,34 @@
+package info.testing.automated.core;
+
+import info.testing.automated.pages.SamplePage;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+import static info.testing.automated.core.Page.*;
+
+/**
+ * Author: Serhii Kuts
+ */
+public class BaseTest {
+
+    private WebDriver driver;
+
+    @BeforeMethod
+    public void setUp() {
+        driver = new WebDriver();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        if (driver != null) {
+            driver.quit();
+            driver = null;
+        }
+
+        Page.destroy();
+    }
+
+    public SamplePage samplePage() {
+        return (SamplePage) getPage(SAMPLE, driver);
+    }
+}

--- a/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/core/Page.java
+++ b/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/core/Page.java
@@ -1,0 +1,47 @@
+package info.testing.automated.core;
+
+import info.testing.automated.pages.SamplePage;
+import info.testing.automated.utils.ReflectionUtils;
+
+import java.util.HashMap;
+
+/**
+ * Author: Serhii Kuts
+ */
+public enum Page {
+
+    SAMPLE {
+        BasePage create(final WebDriver driver) {
+            return ReflectionUtils.create(SamplePage.class, driver);
+        }
+    };
+
+    abstract BasePage create(final WebDriver driver);
+
+    private static final ThreadLocal<HashMap<Page, BasePage>> PAGES = new ThreadLocal<>();
+
+    public static BasePage getPage(final Page page, final WebDriver driver) {
+        if (PAGES.get() == null) {
+            PAGES.set(new HashMap<Page, BasePage>());
+        }
+
+        if (PAGES.get().get(page) == null) {
+            for (Page currentPage : Page.values()) {
+                if (currentPage.equals(page)) {
+                    PAGES.get().put(currentPage, currentPage.create(driver));
+                    break;
+                }
+            }
+        }
+
+        return PAGES.get().get(page);
+    }
+
+    public static void destroy() {
+        if (PAGES.get() != null) {
+            PAGES.remove();
+        }
+
+        ReflectionUtils.clearMethodsCallsList();
+    }
+}

--- a/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/pages/SamplePage.java
+++ b/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/pages/SamplePage.java
@@ -1,0 +1,33 @@
+package info.testing.automated.pages;
+
+import info.testing.automated.annotations.Publish;
+import info.testing.automated.core.BasePage;
+import info.testing.automated.core.WebDriver;
+
+/**
+ * Author: Serhii Kuts
+ */
+public class SamplePage extends BasePage {
+
+    public SamplePage(WebDriver driver) {
+        super(driver);
+    }
+
+    @Publish
+    public SamplePage firstAction() {
+        return this;
+    }
+
+    public SamplePage secondAction() {
+        return this;
+    }
+
+    @Publish
+    public SamplePage thirdAction() {
+        return this;
+    }
+
+    public SamplePage fourthAction() {
+        return this;
+    }
+}

--- a/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/tests/MethodsInterceptorTests.java
+++ b/functional test automation/webdriver/methods-interceptor/src/test/java/info/testing/automated/tests/MethodsInterceptorTests.java
@@ -1,0 +1,26 @@
+package info.testing.automated.tests;
+
+import info.testing.automated.core.BaseTest;
+import info.testing.automated.utils.ReflectionUtils;
+import org.testng.annotations.Test;
+
+/**
+ * Author: Serhii Kuts
+ */
+public class MethodsInterceptorTests extends BaseTest {
+
+    @Test
+    public void interceptAndPublish() throws Exception {
+        samplePage()
+                .firstAction()
+                .secondAction()
+                .thirdAction()
+                .fourthAction();
+
+        for (String method : ReflectionUtils.getMethodsCallsList()) {
+            System.out.println(method);
+        }
+
+        Thread.sleep(3000);
+    }
+}


### PR DESCRIPTION
- Reflection utils implementation for intercepting methods calls
- Custom annotations for tracking what methods need to be intercepted
- Custom page factory implementation for creating page objects via reflection with methods interceptor
- Simple page object and base test for test background preparation
- Simple test that prints used annotated methods' names

Signed-off-by: Sergey Kuts sergey.s.kuts@gmail.com
